### PR TITLE
Introducing the val function

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -296,9 +296,9 @@ test("should return None optional", () => {
 });
 
 test("should retrieve values (GetValues)", () => {
-  const optionalList = [Some(1), Some(2), Some(3)];
+  const optionalList = [ Some(1), Some(2), Some(3) ];
   const list = GetValues(optionalList);
-  expect(list).toEqual([1, 2, 3]);
+  expect(list).toEqual([ 1, 2, 3 ]);
 });
 
 test("should handle empty list (GetValues)", () => {
@@ -308,16 +308,16 @@ test("should handle empty list (GetValues)", () => {
 });
 
 test("should convert and return a list (ConvertAndGetValues)", () => {
-  const optionalList = [1, 2, 3];
+  const optionalList = [ 1, 2, 3 ];
   const list = ConvertAndGetValues(optionalList, val => val.map(a => a + ""));
-  expect(list).toEqual(["1", "2", "3"]);
+  expect(list).toEqual([ "1", "2", "3" ]);
 });
 
 test("should convert and return a list (ConvertAndGetValuesAsync)", () => {
-  const optionalList = [1, 2, 3];
+  const optionalList = [ 1, 2, 3 ];
   ConvertAndGetValuesAsync(optionalList, async val =>
     val.map(a => a + "")
-  ).then(list => expect(list).toEqual(["1", "2", "3"]));
+  ).then(list => expect(list).toEqual([ "1", "2", "3" ]));
 });
 
 test("it should filter the optional (filter)", () => {
@@ -345,17 +345,17 @@ test("it should filter the optional to none (filterAsync)", () => {
 });
 
 test("it should retrieve the first element of the array as an optional", () => {
-  const arr = [1, 2, 3];
+  const arr = [ 1, 2, 3 ];
   const firstOrNone = FirstOrNone(arr);
-  expect(firstOrNone).toEqual(Some(arr[0]));
-  expect(arr).toEqual([1, 2, 3]);
+  expect(firstOrNone).toEqual(Some(arr[ 0 ]));
+  expect(arr).toEqual([ 1, 2, 3 ]);
 });
 
 test("it should retrieve the last element of the array as an optional", () => {
-  const arr = [1, 2, 3];
+  const arr = [ 1, 2, 3 ];
   const lastOrNone = LastOrNone(arr);
-  expect(lastOrNone).toEqual(Some(arr[arr.length - 1]));
-  expect(arr).toEqual([1, 2, 3]);
+  expect(lastOrNone).toEqual(Some(arr[ arr.length - 1 ]));
+  expect(arr).toEqual([ 1, 2, 3 ]);
 });
 
 test("it should convert the value if none is present", () => {
@@ -380,4 +380,16 @@ test("it should be possible to just give value", () => {
   const convertedValueOrNone = valueOrNone.ifNone(1);
   expect(convertedValueOrNone.hasValue).toBe(true);
   expect(convertedValueOrNone.valueOrFailure()).toBe(1);
+});
+
+test("should return the value (val)", () => {
+  const valueOrNone = new Optional("test");
+  expect(valueOrNone.valueOrFailure()).toBe("test");
+});
+
+test("should fail with an error (val)", () => {
+  const valueOrNone = new Optional(undefined);
+  expect(() => {
+    valueOrNone.valueOrFailure();
+  }).toThrowError("There exists no value");
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export class Optional<T> {
   private readonly value: T;
   public readonly hasValue: boolean;
 
-  constructor(value: T | undefined | null) {
+  constructor (value: T | undefined | null) {
     if (value === undefined || value === null) this.hasValue = false;
     else {
       this.hasValue = true;
@@ -114,6 +114,10 @@ export class Optional<T> {
     return alternative;
   }
 
+  val(): T {
+    return this.valueOrFailure();
+  }
+
   valueOrFailure(message?: string): T {
     if (this.hasValue) return this.value;
     throw new Error(message ? message : "There exists no value");
@@ -175,9 +179,9 @@ export async function ConvertAndGetValuesAsync<A, B>(
 }
 
 export function FirstOrNone<T>(values: T[]): Optional<T> {
-  return values.length > 0 ? Some(values[0]) : None();
+  return values.length > 0 ? Some(values[ 0 ]) : None();
 }
 
 export function LastOrNone<T>(values: T[]): Optional<T> {
-  return values.length > 0 ? Some(values[values.length - 1]) : None();
+  return values.length > 0 ? Some(values[ values.length - 1 ]) : None();
 }


### PR DESCRIPTION
Introduced the `val` function which simply is a short cut for `valueOrFailure` with no arguments. 

The reason for picking `val` rather than `value` is `value` is already used privately to store the value within the optional. 

Fixes #8